### PR TITLE
Allow retrieval of VNC information.

### DIFF
--- a/lib/vmapi.js
+++ b/lib/vmapi.js
@@ -310,6 +310,36 @@ VMAPI.prototype.getVmProc = function (params, options, callback) {
 };
 
 
+/**
+ * Gets a KVM VM's VNC information by UUID
+ *
+ * @param {Object} params : Filter params.
+ * @param {String} params.uuid : the UUID of the VM.
+ * @param {Object} options : Request options.
+ * @param {Function} callback : of the form f(err, vm).
+ */
+VMAPI.prototype.getVmVnc = function (params, options, callback) {
+    var query = {};
+
+    if (typeof (options) === 'function') {
+        callback = options;
+        options = undefined;
+    }
+
+    if (!params || typeof (params) !== 'object')
+        throw new TypeError('params is required (object)');
+    if (!params.uuid)
+        throw new TypeError('UUID is required');
+
+    var opts = { path: format('/vms/%s/vnc', params.uuid), query: query };
+    if (options) {
+        opts.headers = options.headers;
+        opts.log = options.log || this.log;
+    }
+
+    return this.get(opts, callback);
+};
+
 
 /**
  * Gets a VM by UUID and/or owner

--- a/test/vmapi.test.js
+++ b/test/vmapi.test.js
@@ -207,6 +207,13 @@ exports.test_get_vm = function (test) {
     });
 };
 
+exports.test_get_vm_vnc = function (test) {
+    vmapi.getVm({ uuid: ZONE }, function (err, vm) {
+        test.ifError(err);
+        test.ok(vm);
+        test.done();
+    });
+};
 
 exports.find_headnode = function (t) {
     cnapi.listServers(function (err, servers) {


### PR DESCRIPTION
This enables VNC information to be obtained through the sdc-vmapi client. This commit depends on the functionality added in https://github.com/joyent/sdc-vmapi/pull/1
