### PR TITLE
ZAPI-655: add test for paginating listVms

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,14 @@
     "backoff": "^2.4.1",
     "bunyan": "^1.2.3",
     "clone": "0.1.8",
-    "libuuid": "0.1.4",
+    "ufds": "git://github.com/joyent/node-ufds.git#a7c674b76696fe7ab0fff1e2486f20d3af6a0d1a",
     "lru-cache": "2.3.0",
+    "libuuid": "0.1.4",
     "once": "^1.3.1",
     "restify": "git://github.com/joyent/node-restify.git#fd5d5b5",
-    "smartdc-auth": "2.1.6",
-    "ufds": "git://github.com/joyent/node-ufds.git#a7c674b76696fe7ab0fff1e2486f20d3af6a0d1a",
     "vasync": "^1.6.2",
     "verror": "^1.6.0",
-    "vmapi": "git://github.com/joyent/sdc-vmapi.git#83ff20bed40b465ec6e9f3506a6557dc029eee64"
+    "smartdc-auth": "2.1.6"
   },
   "devDependencies": {
     "nodeunit": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
     "backoff": "^2.4.1",
     "bunyan": "^1.2.3",
     "clone": "0.1.8",
-    "ufds": "git://github.com/joyent/node-ufds.git#a7c674b76696fe7ab0fff1e2486f20d3af6a0d1a",
-    "lru-cache": "2.3.0",
     "libuuid": "0.1.4",
+    "lru-cache": "2.3.0",
     "once": "^1.3.1",
     "restify": "git://github.com/joyent/node-restify.git#fd5d5b5",
+    "smartdc-auth": "2.1.6",
+    "ufds": "git://github.com/joyent/node-ufds.git#a7c674b76696fe7ab0fff1e2486f20d3af6a0d1a",
     "vasync": "^1.6.2",
     "verror": "^1.6.0",
-    "smartdc-auth": "2.1.6"
+    "vmapi": "git://github.com/joyent/sdc-vmapi.git#83ff20bed40b465ec6e9f3506a6557dc029eee64"
   },
   "devDependencies": {
     "nodeunit": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "smartdc-auth": "2.1.6"
   },
   "devDependencies": {
+    "ldapjs": "^1.0.0",
+    "moray": "git+ssh://git@github.com:joyent/node-moray.git#441fd44",
     "nodeunit": "0.8.0"
   },
   "engines": {


### PR DESCRIPTION
Adds a test that makes sure that listing more than the maximum number of
VMs returned in one page by VMAPI works.

This change uses vmapi as a module, which is the least hacky way I came up with to be able to:
1. Create test VM entries in moray without going through VMAPI's REST API and thus have to queue deletion of VMs in workflow
2. Reuse the code that implements creating/removing "fake" VM entries in moray.
3. Know what the actual maximum number of VM entries returned in a single response from VMAPI /vms endpoint is.

I'm open to suggestions if you have any thoughts on how to do that in a cleaner way.

This PR depends on https://github.com/joyent/sdc-vmapi/pull/5. When https://github.com/joyent/sdc-vmapi/pull/5 lands in sdc-vmapi, the reference to VMAPI's repository in package.json will be updated to point to Joyent's repo.

/cc @trentm @joshwilsdon @jclulow @rmustacc