### PR TITLE
Revert "ZAPI-655: add test for paginating listVms"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "smartdc-auth": "2.1.6"
   },
   "devDependencies": {
-    "ldapjs": "^1.0.0",
-    "moray": "git+ssh://git@github.com:joyent/node-moray.git#441fd44",
     "nodeunit": "0.8.0"
   },
   "engines": {

--- a/test/vmapi.test.js
+++ b/test/vmapi.test.js
@@ -8,27 +8,23 @@
  * Copyright (c) 2014, Joyent, Inc.
  */
 
-var util = require('util');
-
 var Logger = require('bunyan');
 var restify = require('restify');
 var libuuid = require('libuuid');
-var vasync = require('vasync');
-var moray = require('moray');
-var ldapjs = require('ldapjs');
-var assert = require('assert-plus');
-
+function uuid() {
+    return (libuuid.create());
+}
+var util = require('util');
 var VMAPI = require('../lib/index').VMAPI;
 var NAPI = require('../lib/index').NAPI;
 var CNAPI = require('../lib/index').CNAPI;
+
 
 // --- Globals
 
 var VMAPI_URL = 'http://' + (process.env.VMAPI_IP || '10.99.99.27');
 var NAPI_URL = 'http://' + (process.env.NAPI_IP || '10.99.99.10');
 var CNAPI_URL = 'http://' + (process.env.CNAPI_IP || '10.99.99.22');
-
-var VMAPI_VMS_BUCKET_NAME = 'vmapi_vms';
 
 var vmapi = null;
 var napi = null;
@@ -65,17 +61,6 @@ var ROLE_TAG_TWO = '25a852d6-cf2c-11e3-a59f-77a5d70ae240';
 // In seconds
 var TIMEOUT = 90;
 
-var TEST_VMS_ALIAS = 'test-vmapi-node-sdc-clients';
-
-// These constants are used for the pagination tests.
-// Create a number of VMs that is large enough to make VMAPI use the pagination
-// logic when listing them. Currently, VMAPI sets the limit for the number of
-// entries that can be listed in one page to 1000.
-var LIST_VMS_PAGINATION_LIMIT = 1000;
-var NB_PAGINATION_TEST_VMS_TO_CREATE = LIST_VMS_PAGINATION_LIMIT * 2 + 1;
-
-var testPaginationVms;
-var leftoverTestPaginationVms;
 
 // --- Helpers
 
@@ -125,121 +110,6 @@ function waitForValue(fn, params, prop, value, callback) {
     return check();
 }
 
-function connectToMoray(callback) {
-    var MORAY_CLIENT_CONFIG = {
-        host: process.env.MORAY_IP || '10.99.99.17',
-        port: 2020,
-        log: new Logger({
-            name: 'moray',
-            level: 'info',
-            serializers: restify.bunyan.serializers
-        }),
-        connectTimeout: 200,
-        retry: {
-            retries: 2,
-            minTimeout: 500
-        }
-    };
-    var morayClient = moray.createClient(MORAY_CLIENT_CONFIG);
-
-    morayClient.on('connect', function onConnect() {
-        return callback(null, morayClient);
-    });
-}
-
-/*
- * Creates "nbTestVms" VMs in moray. These test VMs will be created with an
- * alias of TEST_VMS_ALIAS to be able to differentiate test VMs from non-test
- * VMs when, for instance, it's time to clean them up.
- * "vmProperties" is an object that contains properties names and properties
- * values that need to be set for all created VMs.
- * "callback" is called with an error object as its first argument, which is
- * null or undefined if there was no error.
- */
-function createTestVms(nbTestVms, vmProperties, callback) {
-    assert.number(nbTestVms, 'nbTestVms must be a number');
-    assert.object(vmProperties, 'vmProperties must be an object');
-    assert.func(callback, 'cb must be a function');
-
-    vasync.waterfall([
-        connectToMoray,
-        function createVms(morayClient, next) {
-            var addVmsQueue = vasync.queue(createTestVm, 10);
-            for (var i = 0; i < nbTestVms; ++i) {
-                addVmsQueue.push(libuuid.create());
-            }
-
-            addVmsQueue.close();
-            addVmsQueue.on('end', function testVmsCreationDone() {
-                return next(null, morayClient);
-            });
-
-            function createTestVm(vmUuid, callback) {
-                var vmObject = {
-                    uuid: vmUuid,
-                    alias: TEST_VMS_ALIAS
-                };
-
-                for (var vmPropertyName in vmProperties) {
-                    vmObject[vmPropertyName] = vmProperties[vmPropertyName];
-                }
-
-                morayClient.putObject(VMAPI_VMS_BUCKET_NAME, vmUuid, vmObject,
-                    callback);
-            }
-        },
-        function closeMorayClient(morayClient, next) {
-            morayClient.close();
-            return next();
-        }
-    ], function creationDone(err, results) {
-        return callback(err);
-    });
-}
-
-/*
- * Deletes VMs in moray that have the alias TEST_VMS_ALIAS and that have
- * property values that match what is passed as the "vmProperties" parameter.
- * "callback" is called with an error object as its first argument, which is
- * null or undefined if there was no error.
- */
-function cleanupTestVms(vmProperties, callback) {
-    assert.object(vmProperties, 'vmProperties must be an object');
-    assert.func(callback, 'callback must be a function');
-
-    vasync.waterfall([
-        connectToMoray,
-        function deleteRunningTestVms(morayClient, next) {
-            var filters = [
-                new ldapjs.EqualityFilter({
-                    attribute: 'alias',
-                    value: TEST_VMS_ALIAS
-                })
-            ];
-
-            for (var vmPropertyName in vmProperties) {
-                filters.push(new ldapjs.EqualityFilter({
-                    attribute: vmPropertyName,
-                    value: vmProperties[vmPropertyName]
-                }));
-            }
-
-            var filter = new ldapjs.AndFilter({filters: filters});
-
-            morayClient.deleteMany(VMAPI_VMS_BUCKET_NAME, filter.toString(),
-                {noLimit: true},
-                function onVmsDeleted(err) {
-                    return next(err, morayClient);
-                });
-        },
-        function closeMorayClient(morayClient, next) {
-            morayClient.close();
-            return next();
-        }
-    ], function cleanupDone(err, results) {
-        return callback(err);
-    });
-}
 
 // --- Tests
 
@@ -301,45 +171,6 @@ exports.test_list_networks = function (test) {
     });
 };
 
-exports.cleanup_leftover_test_vms = function (test) {
-    cleanupTestVms({state: 'running'}, function cleanupDone(err) {
-        test.ifError(err);
-        test.done();
-    });
-};
-
-// Create enough fake VMs so that listing them all requires paginating through
-// several pages.
-exports.create_test_list_pagination_vms = function (test) {
-    createTestVms(NB_PAGINATION_TEST_VMS_TO_CREATE, {state: 'running'},
-        function onTestVmsCreated(err) {
-            test.ifError(err);
-            test.done();
-        });
-};
-
-exports.test_list_pagination_vms = function (test) {
-    vmapi.listVms({
-        alias: TEST_VMS_ALIAS,
-        state: 'running'
-    }, function (err, vms) {
-        test.ifError(err);
-        test.ok(vms);
-        // Make sure _all_ vms are returned, not just the first page
-        test.equal(vms.length, NB_PAGINATION_TEST_VMS_TO_CREATE,
-            'listVms should return ' + NB_PAGINATION_TEST_VMS_TO_CREATE +
-            ' VMs, but instead returned ' + vms.length);
-        testPaginationVms = vms;
-        test.done();
-    });
-};
-
-exports.remove_test_list_pagination_vms = function (test) {
-    cleanupTestVms({state: 'running'}, function cleanupDone(err) {
-        test.ifError(err);
-        test.done();
-    });
-};
 
 exports.test_list_vms = function (test) {
     vmapi.listVms(function (err, vms) {


### PR DESCRIPTION
This reverts commit ad375aebbf29ea1f1445bac4444679267ded66b8, which
caused vmapi tests to hang when running on nightly.

After further investigation, it turns out that vmapi tests also hang
sometimes on my COAL, potentially due to MORAY-324.

In other words, this needs to be made more robust before it gets in, my
apologies for the inconvenience.

/cc @trentm