### PR TITLE
TOOLS-1328 NAPI tests make an incorrect assumption about network ordering

### DIFF
--- a/lib/cns.js
+++ b/lib/cns.js
@@ -32,7 +32,7 @@ util.inherits(CNS, RestifyClient);
  * @param {Function} callback : of the form f(err)
  */
 CNS.prototype.ping = function (options, callback) {
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -54,7 +54,7 @@ CNS.prototype.ping = function (options, callback) {
  */
 CNS.prototype.getVM = function (uuid, options, callback) {
     assert.uuid(uuid, 'uuid');
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -73,7 +73,7 @@ CNS.prototype.getVM = function (uuid, options, callback) {
  * @param {Function} callback : of the form f(err, objs)
  */
 CNS.prototype.listPeers = function (options, callback) {
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -94,7 +94,7 @@ CNS.prototype.listPeers = function (options, callback) {
  */
 CNS.prototype.getPeer = function (address, options, callback) {
     assert.string(address, 'address');
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -116,7 +116,7 @@ CNS.prototype.getPeer = function (address, options, callback) {
  */
 CNS.prototype.deletePeer = function (address, options, callback) {
     assert.string(address, 'address');
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -135,7 +135,7 @@ CNS.prototype.deletePeer = function (address, options, callback) {
  * @param {Function} callback : of the form f(err, objs)
  */
 CNS.prototype.listZones = function (options, callback) {
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }
@@ -155,7 +155,7 @@ CNS.prototype.listZones = function (options, callback) {
  * @param {Function} callback : of the form f(err, objs)
  */
 CNS.prototype.listAllowedPeers = function (options, callback) {
-    if (typeof(options) === 'function') {
+    if (typeof (options) === 'function') {
         callback = options;
         options = {};
     }

--- a/test/napi.test.js
+++ b/test/napi.test.js
@@ -76,8 +76,9 @@ exports.setUp = function (callback) {
 
 exports.test_list_networks = function (test) {
     napi.listNetworks({}, function (err, networks) {
-        test.ifError(err);
-        test.ok(networks);
+        test.ifError(err, 'listNetworks does not error');
+        test.ok(networks, 'listNetworks returns results');
+        test.ok(networks.length > 0, 'listNetworks non-empty');
         NETWORKS = networks;
         NETWORKS.forEach(function (net) {
             test.ok(net.name, 'NAPI GET /networks name OK');
@@ -93,23 +94,29 @@ exports.test_list_networks = function (test) {
 
 
 exports.test_get_network = function (test) {
-    napi.getNetwork(NETWORKS[0].uuid, function (err, network) {
-        test.ifError(err);
-        test.ok(network);
-        test.equal(network.uuid, NETWORKS[0].uuid);
+    napi.getNetwork(ADMIN.uuid, function (err, network) {
+        test.ifError(err, 'getNetwork does not error');
+        test.ok(network, 'getNetwork returns a result');
+        test.ok(network.uuid, 'result has a uuid');
+        if (network.uuid) {
+            test.strictEqual(network.uuid, ADMIN.uuid);
+        }
         test.done();
     });
 };
 
 
-// should fail since network doesn't belong to given owner
+// should fail since admin network doesn't belong to given owner
 exports.test_get_network_with_params = function (test) {
     var params = { provisionable_by: uuid() };
 
-    napi.getNetwork(NETWORKS[0].uuid, { params: params },
+    napi.getNetwork(ADMIN.uuid, { params: params },
                     function (err, network) {
-        test.ok(err);
-        test.equal(err.message, 'owner cannot provision on network');
+        test.ok(err, 'getNetwork errs with bad provisionable_by');
+        if (err) {
+            test.equal(err.message, 'owner cannot provision on network',
+                'err message as expected');
+        }
         test.done();
     });
 };


### PR DESCRIPTION
Changes `getNetwork` tests to explicitly use `ADMIN` (which should always exist in a reasonable test environment) instead of `NETWORKS[0]`, which relied on network ordering that is not specified by NAPI.

Also adds guards to tests to avoid test-breaking throws when tests fail, at least allowing the rest of the tests to complete. E.g., when an expected object does not exist, avoid testing its properties.

Some very mild clean-up: removes use of `util.isArray()` in favour of `Array.isArray()` for one fewer `require`, aligns all test parameters to `test`, and fixes jsstyle errors in `lib/cns.js`.