### PR TITLE
TRITON-1880 backport imgapi channel support to node-sdc-clients v8.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git://github.com/trentm/restdown
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = git://github.com/davepacheco/jsstyle.git
+	url = https://github.com/joyent/jsstyle.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,14 +5,17 @@
 -->
 
 <!--
-    Copyright 2019 Joyent, Inc.
+    Copyright 2020 Joyent, Inc.
 -->
 
 # sdc-clients Changelog
 
 ## sdc-clients 8.2.0
 
-- Backport of channel support (TRITON-886) from v12.0.0
+- TRITON-886 Add support for `channel` option to IMGAPI client methods.
+  Typically the "channel" is set as an argument to the IMGAPI client
+  constructor. However, it can be useful to use an existing IMGAPI client
+  to make a call for a separate channel.  (Backported from v12.0.0.)
 
 ## sdc-clients 8.1.5
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,20 @@
 -->
 
 <!--
-    Copyright (c) 2014, Joyent, Inc.
+    Copyright 2019 Joyent, Inc.
 -->
 
 # sdc-clients Changelog
+
+## sdc-clients 8.2.0
+
+- Backport of channel support (TRITON-886) from v12.0.0
+
+## sdc-clients 8.1.5
+
+- CNAPI-568: new waitTask, pollTask methods
+- PUBAPI-1068: fabric networks support
+- ZAPI-608: addition of vmapi.createVmAndWait funct
 
 ## sdc-clients 8.1.4
 

--- a/lib/imgapi.js
+++ b/lib/imgapi.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -233,7 +233,7 @@ function simpleMerge(a, b) {
  *        are given, the latter wins.
  *      - `channel` {String} Optional. The channel to use, for IMGAPI servers
  *        that use channels.
- *        See <https://mo.joyent.com/docs/imgapi/master/#ListChannels>.
+ *        See <https://updates.joyent.com/docs/#ListChannels>.
  *      - `user` {String} Optional. Used for basic or http-signature auth.
  *      - `password` {String} Optional. If provided, this implies that basic
  *        auth should be used for client requests.
@@ -278,8 +278,8 @@ function IMGAPI(options) {
     } else {
         this.url = options.url;
     }
-    // _basePath: the URL subpath *without* a trailing '/'
-    this._basePath = parsed.pathname;
+    // the URL subpath *without* a trailing '/' or query params
+    this._basePath = parsed.path.split('?')[0];
     if (this._basePath.slice(-1) === '/') {
         this._basePath = this._basePath.slice(0, -1);
     }
@@ -488,6 +488,9 @@ IMGAPI.prototype.adminGetState = function adminGetState(callback) {
  *      See the doc link above for a full list of supported filters.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param callback {Function} `function (err, images, res)`
  *
  * NOTE about filters.limit and filters.marker:
@@ -511,6 +514,7 @@ IMGAPI.prototype.listImages = function listImages(filters, options, callback) {
     assert.object(filters, 'filters');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     self._getAuthHeaders(function (hErr, headers) {
@@ -531,7 +535,9 @@ IMGAPI.prototype.listImages = function listImages(filters, options, callback) {
 
     function listImagesWithLimit(headers, cb) {
         // limit and marker come straight from filters
-        var path = self._path('/images', filters, {channel: self.channel});
+        var path = self._path('/images', {
+            channel: options.channel || self.channel
+        }, filters);
         var reqOpts = {
             path: path,
             headers: headers
@@ -574,7 +580,9 @@ IMGAPI.prototype.listImages = function listImages(filters, options, callback) {
                 filters.limit = limit;
             }
 
-            var path = self._path('/images', filters, {channel: self.channel});
+            var path = self._path('/images', {
+                channel: options.channel || self.channel
+            }, filters);
             var reqOpts = {
                 path: path,
                 headers: headers
@@ -639,6 +647,9 @@ IMGAPI.prototype.listImages = function listImages(filters, options, callback) {
  *      If given this will only return images accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.getImage =
@@ -660,11 +671,12 @@ function getImage(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path('/images/' + uuid, {
         account: account,
-        channel: self.channel
+        channel: options.channel || self.channel
     });
     self._getAuthHeaders(function (hErr, headers) {
         if (hErr) {
@@ -698,6 +710,9 @@ function getImage(uuid, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.createImage =
@@ -719,9 +734,13 @@ function createImage(data, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
-    var path = self._path('/images', {account: account, channel: self.channel});
+    var path = self._path('/images', {
+        account: account,
+        channel: options.channel || self.channel
+    });
     self._getAuthHeaders(function (hErr, headers) {
         if (hErr) {
             callback(hErr);
@@ -758,6 +777,9 @@ function createImage(data, account, options, callback) {
  *      - incremental {Boolean} Optional. Default false. Create an incremental
  *        image.
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {UUID} account : Optional. The UUID of the account on behalf of whom
  *      this request is being made. If given this will only return images
  *      accessible to that account.
@@ -775,12 +797,13 @@ function createImageFromVm(data, options, account, callback) {
     assert.string(options.vm_uuid, 'options.vm_uuid');
     assert.optionalBool(options.incremental, 'options.incremental');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.optionalString(account, 'account');
     assert.func(callback, 'callback');
 
     var path = self._path('/images');
     path += self._qs({
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'create-from-vm',
         vm_uuid: options.vm_uuid,
         incremental: options.incremental,
@@ -881,6 +904,9 @@ function createImageFromVmAndWait(data, options, account, callback) {
  *          Append '?channel=<channel>' to select a particular source
  *          channel, if relevant.
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.adminImportImage = function adminImportImage(
@@ -895,12 +921,13 @@ IMGAPI.prototype.adminImportImage = function adminImportImage(
     assert.optionalBool(options.skipOwnerCheck, 'options.skipOwnerCheck');
     assert.optionalString(options.source, 'options.source');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
     assert.string(data.uuid, 'data.uuid');
 
     var path = self._path('/images/' + data.uuid);
     path += self._qs({
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'import',
         skip_owner_check: options.skipOwnerCheck,
         source: options.source
@@ -951,6 +978,9 @@ IMGAPI.prototype.adminImportImage = function adminImportImage(
  * @param {Object} options: For backward compat, this argument is optional.
  *      - skipOwnerCheck {Boolean} Optional. Default false.
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.adminImportRemoteImageAndWait =
@@ -965,11 +995,12 @@ function adminImportRemoteImageAndWait(uuid, source, options, callback) {
     assert.object(options, 'options');
     assert.optionalBool(options.skipOwnerCheck, 'options.skipOwnerCheck');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.optionalNumber(options.retries, 'options.retries');
     assert.func(callback, 'callback');
 
     var path = self._path('/images/' + uuid, {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'import-remote',
         source: source,
         skip_owner_check: options.skipOwnerCheck
@@ -1213,6 +1244,9 @@ function pollJob(client, job_uuid, cb) {
  * @param {Object} options: For backward compat, this argument is optional.
  *      - skipOwnerCheck {Boolean} Optional. Default false.
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, job, res)`
  */
 IMGAPI.prototype.adminImportRemoteImage =
@@ -1227,10 +1261,11 @@ function adminImportRemoteImage(uuid, source, options, callback) {
     assert.object(options, 'options');
     assert.optionalBool(options.skipOwnerCheck, 'options.skipOwnerCheck');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path('/images/' + uuid, {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'import-remote',
         source: source,
         skip_owner_check: options.skipOwnerCheck
@@ -1279,6 +1314,9 @@ function adminImportRemoteImage(uuid, source, options, callback) {
  *        Can be "local" or "manta". Will try to default to "manta" when
  *        available, otherwise "local".
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {UUID} account : Optional. The UUID of the account on behalf of whom
  *      this request is being made. If given this will only return images
  *      accessible to that account.
@@ -1290,6 +1328,7 @@ IMGAPI.prototype.addImageFile = function addImageFile(options, account,
     assert.object(options, 'options');
     assert.string(options.uuid, 'options.uuid');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     if (callback === undefined) {
         callback = account;
         account = undefined;
@@ -1301,7 +1340,7 @@ IMGAPI.prototype.addImageFile = function addImageFile(options, account,
     if (options.source) {
         assert.string(options.source, 'options.source');
         var path = self._path(format('/images/%s/file', uuid), {
-            channel: self.channel,
+            channel: options.channel || self.channel,
             source: options.source,
             storage: options.storage
         });
@@ -1364,7 +1403,7 @@ IMGAPI.prototype.addImageFile = function addImageFile(options, account,
         }
 
         var path = self._path(format('/images/%s/file', uuid), {
-            channel: self.channel,
+            channel: options.channel || self.channel,
             compression: options.compression,
             account: account,
             sha1: options.sha1,
@@ -1439,6 +1478,9 @@ IMGAPI.prototype.addImageFile = function addImageFile(options, account,
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, res)`
  */
 IMGAPI.prototype.getImageFile =
@@ -1457,10 +1499,11 @@ function getImageFile(uuid, filePath, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/file', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account
     });
     self._getAuthHeaders(function (hErr, headers) {
@@ -1523,6 +1566,9 @@ function getImageFile(uuid, filePath, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, stream)`
  *      The `stream` is also an HTTP response object, i.e. headers are on
  *      `stream.headers`.
@@ -1542,10 +1588,11 @@ IMGAPI.prototype.getImageFileStream = function getImageFileStream(
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/file', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account
     });
     self._getAuthHeaders(function (hErr, headers) {
@@ -1594,6 +1641,9 @@ IMGAPI.prototype.getImageFileStream = function getImageFileStream(
  *        this is required, otherwise it will be retrieved with `fs.stat`.
  *      - {String} sha1 : SHA-1 hash of the icon file being uploaded.
  *      - headers {Object} Optional Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {UUID} account : Optional. The UUID of the account on behalf of whom
  *      this request is being made. If given this will only return images
  *      accessible to that account.
@@ -1610,6 +1660,7 @@ IMGAPI.prototype.addImageIcon = function addImageIcon(options, account,
     assert.optionalString(options.sha1, 'options.sha1');
     assert.optionalNumber(options.size, 'options.size');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     if (callback === undefined) {
         callback = account;
         account = undefined;
@@ -1646,7 +1697,7 @@ IMGAPI.prototype.addImageIcon = function addImageIcon(options, account,
         }
 
         var path = self._path(format('/images/%s/icon', uuid), {
-            channel: self.channel,
+            channel: options.channel || self.channel,
             account: account,
             sha1: options.sha1
         });
@@ -1718,6 +1769,9 @@ IMGAPI.prototype.addImageIcon = function addImageIcon(options, account,
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, res)`
  */
 IMGAPI.prototype.getImageIcon =
@@ -1736,10 +1790,11 @@ function getImageIcon(uuid, filePath, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/icon', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account
     });
     self._getAuthHeaders(function (hErr, headers) {
@@ -1803,6 +1858,9 @@ function getImageIcon(uuid, filePath, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, stream)`
  *      The `stream` is also an HTTP response object, i.e. headers are on
  *      `stream.headers`.
@@ -1822,10 +1880,11 @@ IMGAPI.prototype.getImageIconStream = function getImageIconStream(
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/icon', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account
     });
     self._getAuthHeaders(function (hErr, headers) {
@@ -1869,6 +1928,9 @@ IMGAPI.prototype.getImageIconStream = function getImageIconStream(
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.deleteImageIcon =
@@ -1886,10 +1948,11 @@ function deleteImageIcon(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/icon', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account
     });
     self._getAuthHeaders(function (hErr, headers) {
@@ -1931,6 +1994,9 @@ function deleteImageIcon(uuid, account, options, callback) {
  *          then the files are saved to it. If the basename of "PATH" is not a
  *          dir, then "PATH.imgmanifest" and "PATH.zfs[.EXT]" are created.
  *      - headers {Object} Optional. Additional request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.exportImage =
@@ -1945,11 +2011,12 @@ function exportImage(uuid, account, options, callback) {
     assert.object(options, 'options');
     assert.string(options.manta_path, 'manta_path');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.optionalString(account, 'account');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'export',
         manta_path: options.manta_path,
         account: account
@@ -1986,6 +2053,9 @@ function exportImage(uuid, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.activateImage =
@@ -2003,10 +2073,11 @@ function activateImage(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'activate',
         account: account
     });
@@ -2042,6 +2113,9 @@ function activateImage(uuid, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.disableImage =
@@ -2059,10 +2133,11 @@ function disableImage(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'disable',
         account: account
     });
@@ -2098,6 +2173,9 @@ function disableImage(uuid, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.enableImage =
@@ -2115,10 +2193,11 @@ function enableImage(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'enable',
         account: account
     });
@@ -2155,6 +2234,9 @@ function enableImage(uuid, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.addImageAcl =
@@ -2173,10 +2255,11 @@ function addImageAcl(uuid, acl, account, options, callback) {
     assert.arrayOfString(acl, 'acl');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/acl', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'add',
         account: account
     });
@@ -2213,6 +2296,9 @@ function addImageAcl(uuid, acl, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.removeImageAcl =
@@ -2231,10 +2317,11 @@ function removeImageAcl(uuid, acl, account, options, callback) {
     assert.arrayOfString(acl, 'acl');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s/acl', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'remove',
         account: account
     });
@@ -2271,6 +2358,9 @@ function removeImageAcl(uuid, acl, account, options, callback) {
  *      accessible to that account.
  * @param options {Object} Optional request options.
  *      - headers {Object} Optional extra request headers.
+ *      - channel {String} Optional override for the channel set on the
+ *        constructor. This is only relevant for IMGAPI servers that
+ *        support channels.
  * @param {Function} callback : `function (err, image, res)`
  */
 IMGAPI.prototype.updateImage =
@@ -2289,10 +2379,11 @@ function updateImage(uuid, data, account, options, callback) {
     assert.object(data, 'data');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         action: 'update',
         account: account
     });
@@ -2355,11 +2446,12 @@ function deleteImage(uuid, account, options, callback) {
     assert.optionalString(account, 'account');
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
+    assert.optionalString(options.channel, 'options.channel');
     assert.optionalBool(options.forceAllChannels, 'options.forceAllChannels');
     assert.func(callback, 'callback');
 
     var path = self._path(format('/images/%s', uuid), {
-        channel: self.channel,
+        channel: options.channel || self.channel,
         account: account,
         force_all_channels: options.forceAllChannels
     });

--- a/lib/imgapi.js
+++ b/lib/imgapi.js
@@ -5,11 +5,11 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
- * Client library for the SDC Image API (IMGAPI).
+ * Client library for the TritonDC Image API (IMGAPI).
  *
  * Usage without auth (e.g. when talking to in-SDC IMGAPI on admin network):
  *
@@ -278,8 +278,8 @@ function IMGAPI(options) {
     } else {
         this.url = options.url;
     }
-    // the URL subpath *without* a trailing '/' or query params
-    this._basePath = parsed.path.split('?')[0];
+    // _basePath: the URL subpath *without* a trailing '/'
+    this._basePath = parsed.pathname;
     if (this._basePath.slice(-1) === '/') {
         this._basePath = this._basePath.slice(0, -1);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdc-clients",
   "description": "Contains node.js client libraries for SDC REST APIs.",
-  "version": "8.1.5",
+  "version": "8.2.0",
   "homepage": "http://www.joyent.com",
   "private": true,
   "repository": {


### PR DESCRIPTION
This was originally PR joyent/node-sdc-clients#18 as created by our gerrit->github automation, but that incorrectly made a PR targeting the 'master' branch rather than the new '8.x' branch. Please see that PR for the comments so far.